### PR TITLE
We can load fixtures implicitly (via the first load of entity fixture) or explicit now

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ Fixtures can be managed through the configuration.
 default:
     extensions:
         Rezzza\AliceExtension\Extension:
+            default_loading: implicit
             fixtures:
                 default: [users, products] # could be scalar if you want only one => users
                 key_paths:
@@ -158,6 +159,7 @@ default:
 ```
 
 With this kind of configuration, when you'll call step below, it'll load **default** fixtures (**users** and **products** in this example).
+**default_loading** key is important here, if it's defined as `implicit`, it'll implicitly load **default** fixtures when you use step below. If it's defined as `explicit` you'll have to use `Given I load "default" fixtures` to load **default** fixtures.
 
 ```
 Given I load "Acme\Bundle\Entity\User" fixtures where column "key" is the key:
@@ -174,6 +176,7 @@ Given I load "products" fixtures  # will load products
 ```
 
 Of course, fixtures are loaded once.
+
 
 
 Faker Providers

--- a/src/Rezzza/AliceExtension/Alice/AliceFixturesExecutor.php
+++ b/src/Rezzza/AliceExtension/Alice/AliceFixturesExecutor.php
@@ -23,11 +23,17 @@ class AliceFixturesExecutor
 
     protected $adapterRegistry;
 
-    public function __construct(SubscriberFactoryRegistry $adapterRegistry, AliceLoader $alice, FixtureStack $fixtureStack)
+    protected $defaultLoading;
+
+    CONST DEFAULT_LOADING_IMPLICIT = 'implicit';
+    CONST DEFAULT_LOADING_EXPLICIT = 'explicit';
+
+    public function __construct(SubscriberFactoryRegistry $adapterRegistry, AliceLoader $alice, FixtureStack $fixtureStack, $defaultLoading = self::DEFAULT_LOADING_IMPLICIT)
     {
         $this->adapterRegistry = $adapterRegistry;
-        $this->alice = $alice;
-        $this->fixtureStack = $fixtureStack;
+        $this->alice           = $alice;
+        $this->fixtureStack    = $fixtureStack;
+        $this->defaultLoading  = $defaultLoading;
     }
 
     public function changeAdapter($name, $fixtureClass)
@@ -40,9 +46,12 @@ class AliceFixturesExecutor
     {
         $this->guardAgainstEmptyAdapterConfig();
 
-        $fixtures = array_map(function($v) {
-            return new YamlFixtures($v);
-        }, $this->fixtureStack->unstack(FixtureStack::DEFAULT_KEY));
+        if ($this->defaultLoading === self::DEFAULT_LOADING_IMPLICIT) {
+            // add defaults fixtures.
+            $fixtures = array_map(function($v) {
+                return new YamlFixtures($v);
+            }, $this->fixtureStack->unstack(FixtureStack::DEFAULT_KEY));
+        }
 
         $fixtures[] = new InlineFixtures($className, $columnKey, $data);
 

--- a/src/Rezzza/AliceExtension/Extension.php
+++ b/src/Rezzza/AliceExtension/Extension.php
@@ -7,6 +7,7 @@ use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Rezzza\AliceExtension\Fixture\FixtureStack;
+use Rezzza\AliceExtension\Alice\AliceFixturesExecutor;
 
 use Behat\Behat\Extension\ExtensionInterface;
 
@@ -26,6 +27,7 @@ class Extension implements ExtensionInterface
         if (isset($config['fixtures'])) {
             $container->setParameter('behat.alice.fixtures.default', $config['fixtures']['default']);
             $container->setParameter('behat.alice.fixtures.key_paths', $config['fixtures']['key_paths']);
+            $container->setParameter('behat.alice.fixtures.default_loading', $config['fixtures']['default_loading']);
         }
 
         if (isset($config['lifetime'])) {
@@ -83,6 +85,13 @@ class Extension implements ExtensionInterface
                         ->thenInvalid("You can't define a default which is not present in key_paths.")
                     ->end()
                     ->children()
+                        ->scalarNode('default_loading')
+                            ->defaultValue(AliceFixturesExecutor::DEFAULT_LOADING_IMPLICIT)
+                            ->validate()
+                                ->ifNotInArray(array(AliceFixturesExecutor::DEFAULT_LOADING_IMPLICIT, AliceFixturesExecutor::DEFAULT_LOADING_EXPLICIT))
+                                ->thenInvalid('fixtures.default_loading should be implicit or explicit.')
+                            ->end()
+                        ->end()
                         ->arrayNode('default')
                             ->beforeNormalization()
                                 ->ifTrue(function($v) {

--- a/src/Rezzza/AliceExtension/Resources/services.xml
+++ b/src/Rezzza/AliceExtension/Resources/services.xml
@@ -32,6 +32,7 @@
             <argument type="service" id="behat.alice.subscriber_factory.registry" />
             <argument type="service" id="behat.alice.loader" />
             <argument type="service" id="behat.alice.fixture_stack" />
+            <argument>%behat.alice.fixtures.default_loading%</argument>
         </service>
 
         <service id="behat.alice.fixture_stack" class="%behat.alice.fixture_stack.class%">


### PR DESCRIPTION
| Bug fix | no |
| --- | --- |
| Feature addition | yes |
| Backwards compatibility break | no |
| Symfony2 tests pass | yes |
| License of the code | MIT |
| Documentation PR | [here](https://github.com/rezzza/alice-extension/tree/default_loading_modes#advanced-fixtures) |
