### PR TITLE
No more DROP TABLE on Doctrine embeddable class

### DIFF
--- a/src/Rezzza/AliceExtension/Doctrine/ORMPurger.php
+++ b/src/Rezzza/AliceExtension/Doctrine/ORMPurger.php
@@ -104,6 +104,10 @@ class ORMPurger
 
         $tables = array();
         foreach ($metadatas as $metadata) {
+            if (true === $metadata->isEmbeddedClass) {
+                continue;
+            }
+
             if (!$metadata->isMappedSuperclass) {
                 $tables[] = $metadata->getQuotedTableName($platform);
             }


### PR DESCRIPTION
Currently when we are using [Doctrine Embeddable](http://doctrine-orm.readthedocs.org/projects/doctrine-orm/en/latest/tutorials/embeddables.html). We get the following error when the extension is resetting the test database :

```cli
[Doctrine\DBAL\Exception\TableNotFoundException]                             
  An exception occurred while executing 'TRUNCATE stock':                      
  SQLSTATE[42S02]: Base table or view not found: 1146 Table 'db_test.stock' doesn't exist                                                      
                                                                               

                                                                               
  [Doctrine\DBAL\Driver\PDOException]                                          
  SQLSTATE[42S02]: Base table or view not found: 1146 Table 'db_test.stock' doesn't exist                                                      
                                                                               

                                                                               
  [PDOException]                                                               
  SQLSTATE[42S02]: Base table or view not found: 1146 Table 'db_test.stock' doesn't exist 
```

Because we are trying to DROP TABLE a not existing table.

Keep up the good work !
