### PR TITLE
Lead AliceExtension to be SF3 ready

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ php:
     - 7.0
 
 install:
+    - composer self-update
     - git clone --branch trusty --depth=1 https://github.com/rezzza/travis-ci.git ~/.rezzza.travis-ci
     - ~/.rezzza.travis-ci/php/bootstrap.sh apcu
     - phpenv rehash

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "atoum/atoum": "~2.0",
         "doctrine/orm": "~2.2,>=2.2.3",
         "doctrine/doctrine-bundle": "~1.2",
-        "symfony/symfony": "~2.3"
+        "symfony/symfony": "~2.3|~3.0"
     },
 
     "suggest": {

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "php":                      ">=5.3.2",
         "behat/behat":              "~3.0",
         "behat/symfony2-extension": "~2.0",
-        "nelmio/alice":             "~1.7",
+        "nelmio/alice":             "~2.1",
         "doctrine/data-fixtures":   "2.0.*@dev"
     },
 

--- a/src/Rezzza/AliceExtension/Adapter/ORM/ORMEventSubscriber.php
+++ b/src/Rezzza/AliceExtension/Adapter/ORM/ORMEventSubscriber.php
@@ -8,7 +8,7 @@ use Doctrine\Fixture\Event\FixtureEvent;
 use Doctrine\Fixture\Event\ImportFixtureEventListener;
 use Doctrine\Fixture\Event\PurgeFixtureEventListener;
 use Doctrine\Fixture\Persistence\ManagerRegistryEventSubscriber;
-use Nelmio\Alice\ORM\Doctrine as ORMPersister;
+use Nelmio\Alice\Persister\Doctrine as ORMPersister;
 
 use Rezzza\AliceExtension\Doctrine\ORMPurger;
 

--- a/src/Rezzza/AliceExtension/Adapter/ORM/ORMPersistFixture.php
+++ b/src/Rezzza/AliceExtension/Adapter/ORM/ORMPersistFixture.php
@@ -2,7 +2,7 @@
 
 namespace Rezzza\AliceExtension\Adapter\ORM;
 
-use Nelmio\Alice\ORM\Doctrine as ORMPersister;
+use Nelmio\Alice\Persister\Doctrine as ORMPersister;
 
 interface ORMPersistFixture
 {

--- a/src/Rezzza/AliceExtension/Adapter/ORM/ORMSubscriberFactory.php
+++ b/src/Rezzza/AliceExtension/Adapter/ORM/ORMSubscriberFactory.php
@@ -3,7 +3,7 @@
 namespace Rezzza\AliceExtension\Adapter\ORM;
 
 use Doctrine\Common\Persistence\ManagerRegistry;
-use Nelmio\Alice\ORM\Doctrine as ORMPersister;
+use Nelmio\Alice\Persister\Doctrine as ORMPersister;
 use Rezzza\AliceExtension\Doctrine\ORMPurger;
 
 class ORMSubscriberFactory

--- a/src/Rezzza/AliceExtension/Alice/AggregateProcessorRegistry.php
+++ b/src/Rezzza/AliceExtension/Alice/AggregateProcessorRegistry.php
@@ -4,10 +4,15 @@ namespace Rezzza\AliceExtension\Alice;
 
 class AggregateProcessorRegistry implements ProcessorRegistry
 {
+    /** @var ProcessorRegistry[] */
     private $registries = array();
 
+    /** @var \Nelmio\Alice\ProcessorInterface[] */
     private $processors = array();
 
+    /**
+     * @param ProcessorRegistry[] $registries
+     */
     public function __construct(array $registries = array())
     {
         foreach ($registries as $registry) {
@@ -15,6 +20,9 @@ class AggregateProcessorRegistry implements ProcessorRegistry
         }
     }
 
+    /**
+     * @inheritdoc
+     */
     public function get($className)
     {
         if (!$this->has($className)) {
@@ -31,6 +39,9 @@ class AggregateProcessorRegistry implements ProcessorRegistry
         return $this->processors[$className];
     }
 
+    /**
+     * @inheritdoc
+     */
     public function has($className)
     {
         return isset($this->processors[$className]);

--- a/src/Rezzza/AliceExtension/Alice/AliceFixture.php
+++ b/src/Rezzza/AliceExtension/Alice/AliceFixture.php
@@ -2,11 +2,11 @@
 
 namespace Rezzza\AliceExtension\Alice;
 
-use Nelmio\Alice\Loader\Base as AliceLoader;
+use Nelmio\Alice\Fixtures\Loader;
 
 interface AliceFixture
 {
     public function setAliceFixtures(AliceFixtures $fixtures);
 
-    public function setAlice(AliceLoader $alice);
+    public function setAlice(Loader $alice);
 }

--- a/src/Rezzza/AliceExtension/Alice/AliceFixture.php
+++ b/src/Rezzza/AliceExtension/Alice/AliceFixture.php
@@ -2,8 +2,6 @@
 
 namespace Rezzza\AliceExtension\Alice;
 
-use Nelmio\Alice\Fixtures\Loader;
-
 interface AliceFixture
 {
     public function setAliceFixtures(AliceFixtures $fixtures);

--- a/src/Rezzza/AliceExtension/Alice/AliceFixturesExecutor.php
+++ b/src/Rezzza/AliceExtension/Alice/AliceFixturesExecutor.php
@@ -101,7 +101,7 @@ class AliceFixturesExecutor
         $this->execute($configuration, Executor::PURGE);
     }
 
-    private function execute($configuration, $flag)
+    private function execute(Configuration $configuration, $flag)
     {
         $executor      = new Executor($configuration);
         $classLoader   = new ClassLoader(array($this->fixtureClass));

--- a/src/Rezzza/AliceExtension/Alice/Fixture/AliceFixturesEventSubscriber.php
+++ b/src/Rezzza/AliceExtension/Alice/Fixture/AliceFixturesEventSubscriber.php
@@ -5,18 +5,20 @@ namespace Rezzza\AliceExtension\Alice\Fixture;
 use Doctrine\Common\EventSubscriber;
 use Doctrine\Fixture\Event\FixtureEvent;
 use Doctrine\Fixture\Event\ImportFixtureEventListener;
-use Nelmio\Alice\Loader\Base as AliceLoader;
+use Nelmio\Alice\Fixtures\Loader;
 
 use Rezzza\AliceExtension\Alice\AliceFixture;
 use Rezzza\AliceExtension\Alice\AliceFixtures;
 
 class AliceFixturesEventSubscriber implements EventSubscriber, ImportFixtureEventListener
 {
+    /** @var AliceFixtures */
     private $fixtures;
 
+    /** @var Loader */
     private $alice;
 
-    public function __construct(AliceLoader $alice, AliceFixtures $fixtures)
+    public function __construct(Loader $alice, AliceFixtures $fixtures)
     {
         $this->alice = $alice;
         $this->fixtures = $fixtures;

--- a/src/Rezzza/AliceExtension/Alice/InlineFixtures.php
+++ b/src/Rezzza/AliceExtension/Alice/InlineFixtures.php
@@ -40,10 +40,25 @@ class InlineFixtures implements AliceFixtures
         $result = array();
 
         foreach ($data as $key => $value) {
+            $value = $this->cleanFixtureReferenceToBeYamlCompliant($value);
+
             // Always parse with Yaml to support array, true, false and null values
             $result[$key] = YamlParser::parse($value);
         }
 
         return $result;
+    }
+
+    /**
+     * @param string $value
+     * @return string
+     */
+    private function cleanFixtureReferenceToBeYamlCompliant($value)
+    {
+        if (0 == preg_match("#^@(.*)$#i", $value)) {
+            return $value;
+        }
+
+        return sprintf('"%s"', $value);
     }
 }

--- a/src/Rezzza/AliceExtension/Alice/InlineFixtures.php
+++ b/src/Rezzza/AliceExtension/Alice/InlineFixtures.php
@@ -19,6 +19,9 @@ class InlineFixtures implements AliceFixtures
         $this->data = $data;
     }
 
+    /**
+     * @inheritdoc
+     */
     public function load()
     {
         $rows = array();

--- a/src/Rezzza/AliceExtension/Alice/Loader.php
+++ b/src/Rezzza/AliceExtension/Alice/Loader.php
@@ -2,14 +2,15 @@
 
 namespace Rezzza\AliceExtension\Alice;
 
-use Doctrine\Common\Persistence\ObjectManager;
-use Nelmio\Alice\Loader\Base;
-use Nelmio\Alice\ORMInterface;
+use Nelmio\Alice\Fixtures\Loader as BaseLoader;
+use Nelmio\Alice\PersisterInterface;
 
-class Loader extends Base
+class Loader extends BaseLoader
 {
+    /** @var ProcessorRegistry */
     private $processorRegistry;
 
+    /** @var PersisterInterface */
     private $persister;
 
     public function __construct(ProcessorRegistry $processorRegistry, $locale = "en_US", array $providers = array())
@@ -18,7 +19,7 @@ class Loader extends Base
         $this->processorRegistry = $processorRegistry;
     }
 
-    public function changePersister($persister)
+    public function setPersister(PersisterInterface $persister)
     {
         $this->persister = $persister;
 

--- a/src/Rezzza/AliceExtension/Alice/MultipleFixtures.php
+++ b/src/Rezzza/AliceExtension/Alice/MultipleFixtures.php
@@ -4,6 +4,7 @@ namespace Rezzza\AliceExtension\Alice;
 
 class MultipleFixtures implements AliceFixtures
 {
+    /** @var AliceFixtures[] */
     private $fixtureRows;
 
     public function __construct(array $fixtureRows)
@@ -11,6 +12,9 @@ class MultipleFixtures implements AliceFixtures
         $this->fixtureRows = $fixtureRows;
     }
 
+    /**
+     * @inheritdoc
+     */
     public function load()
     {
         $results = array();

--- a/src/Rezzza/AliceExtension/Alice/ProcessorRegistry.php
+++ b/src/Rezzza/AliceExtension/Alice/ProcessorRegistry.php
@@ -2,11 +2,17 @@
 
 namespace Rezzza\AliceExtension\Alice;
 
-use Nelmio\Alice\ProcessorInterface;
-
 interface ProcessorRegistry
 {
+    /**
+     * @param string $className
+     * @return \Nelmio\Alice\ProcessorInterface[]
+     */
     public function get($className);
 
+    /**
+     * @param string $className
+     * @return bool
+     */
     public function has($className);
 }

--- a/src/Rezzza/AliceExtension/Alice/YamlFixtures.php
+++ b/src/Rezzza/AliceExtension/Alice/YamlFixtures.php
@@ -13,6 +13,9 @@ class YamlFixtures implements AliceFixtures
         $this->file = $file;
     }
 
+    /**
+     * @inheritdoc
+     */
     public function load()
     {
         return $this->loadYaml($this->file);

--- a/src/Rezzza/AliceExtension/Compiler/SubscriberFactoryPass.php
+++ b/src/Rezzza/AliceExtension/Compiler/SubscriberFactoryPass.php
@@ -2,8 +2,7 @@
 
 namespace Rezzza\AliceExtension\Compiler;
 
-use Symfony\Component\DependencyInjection\Reference,
-    Symfony\Component\DependencyInjection\ContainerBuilder,
+use Symfony\Component\DependencyInjection\ContainerBuilder,
     Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 
 class SubscriberFactoryPass implements CompilerPassInterface

--- a/src/Rezzza/AliceExtension/Context/AliceContext.php
+++ b/src/Rezzza/AliceExtension/Context/AliceContext.php
@@ -3,16 +3,14 @@
 namespace Rezzza\AliceExtension\Context;
 
 use Behat\Behat\Context\Context as BehatContext;
-use Behat\Behat\Event\ScenarioEvent;
-use Behat\Behat\Event\FeatureEvent;
 use Behat\Gherkin\Node\TableNode;
 
 use Rezzza\AliceExtension\Alice\AliceAwareInterface;
 use Rezzza\AliceExtension\Alice\AliceFixturesExecutor;
-use Rezzza\AliceExtension\Doctrine\ORMInitializer;
 
 class AliceContext implements BehatContext, AliceAwareInterface
 {
+    /** @var AliceFixturesExecutor */
     private $executor;
 
     public function setExecutor(AliceFixturesExecutor $executor)

--- a/src/Rezzza/AliceExtension/Context/EventSubscriber/HookListener.php
+++ b/src/Rezzza/AliceExtension/Context/EventSubscriber/HookListener.php
@@ -39,7 +39,7 @@ class HookListener implements EventSubscriberInterface
     /**
      * Listens to "feature.before" event.
      *
-     * @param \Behat\Behat\Event\FeatureEvent $event
+     * @param BeforeFeatureTested $event
      */
     public function beforeFeature(BeforeFeatureTested $event)
     {
@@ -56,7 +56,7 @@ class HookListener implements EventSubscriberInterface
     /**
      * Listens to "scenario.before" event.
      *
-     * @param \Behat\Behat\Event\ScenarioEvent $event
+     * @param BeforeScenarioTested $event
      */
     public function beforeScenario(BeforeScenarioTested $event)
     {

--- a/src/Rezzza/AliceExtension/Context/Initializer/AliceExecutorInitializer.php
+++ b/src/Rezzza/AliceExtension/Context/Initializer/AliceExecutorInitializer.php
@@ -20,7 +20,7 @@ class AliceExecutorInitializer implements ContextInitializer
     /**
      * Checks if initializer supports provided context.
      *
-     * @param ContextInterface $context
+     * @param Context $context
      *
      * @return Boolean
      */

--- a/src/Rezzza/AliceExtension/Doctrine/ORMPersister.php
+++ b/src/Rezzza/AliceExtension/Doctrine/ORMPersister.php
@@ -3,7 +3,7 @@
 namespace Rezzza\AliceExtension\Doctrine;
 
 use Doctrine\Common\Persistence\ManagerRegistry;
-use Nelmio\Alice\ORM\Doctrine;
+use Nelmio\Alice\Persister\Doctrine;
 
 class ORMPersister extends Doctrine
 {

--- a/src/Rezzza/AliceExtension/Fixture/ElasticaFixture.php
+++ b/src/Rezzza/AliceExtension/Fixture/ElasticaFixture.php
@@ -4,7 +4,7 @@ namespace Rezzza\AliceExtension\Fixture;
 
 use Doctrine\Fixture\Fixture;
 use FOS\ElasticaBundle\Index\Resetter;
-use Nelmio\Alice\Loader\Base as AliceLoader;
+use Nelmio\Alice\Fixtures\Loader;
 
 use Rezzza\AliceExtension\Alice\AliceFixture;
 use Rezzza\AliceExtension\Alice\AliceFixtures;
@@ -48,7 +48,7 @@ class ElasticaFixture implements ElasticaPersistFixture, ElasticaResetFixture, A
         $this->fixtures = $fixtures;
     }
 
-    public function setAlice(AliceLoader $alice)
+    public function setAlice(Loader $alice)
     {
         $this->alice = $alice;
     }

--- a/src/Rezzza/AliceExtension/Fixture/ORMFixture.php
+++ b/src/Rezzza/AliceExtension/Fixture/ORMFixture.php
@@ -4,33 +4,36 @@ namespace Rezzza\AliceExtension\Fixture;
 
 use Doctrine\Common\Persistence\ManagerRegistry;
 use Doctrine\Fixture\Persistence\ManagerRegistryFixture;
-use Nelmio\Alice\Loader\Base as AliceLoader;
-use Nelmio\Alice\ORM\Doctrine as ORMPersister;
+use Nelmio\Alice\Persister\Doctrine as ORMPersister;
 
 use Rezzza\AliceExtension\Alice\AliceFixture;
 use Rezzza\AliceExtension\Alice\AliceFixtures;
+use Rezzza\AliceExtension\Alice\Loader;
 use Rezzza\AliceExtension\Doctrine\ORMPurger;
 use Rezzza\AliceExtension\Adapter\ORM\ORMPersistFixture;
 use Rezzza\AliceExtension\Adapter\ORM\ORMResetFixture;
 
 class ORMFixture implements ManagerRegistryFixture, AliceFixture, ORMPersistFixture, ORMResetFixture
 {
+    /** @var ManagerRegistry */
     private $managerRegistry;
 
+    /** @var ORMPersister */
     private $persister;
 
+    /** @var ORMPurger */
     private $purger;
 
+    /** @var AliceFixtures */
     private $fixtures;
 
+    /** @var Loader */
     private $alice;
 
     public function import()
     {
-        $this->alice
-            ->changePersister($this->persister)
-            ->load($this->fixtures->load())
-        ;
+        $this->alice->setPersister($this->persister);
+        $this->alice->load($this->fixtures->load());
 
         // Ensure to close the connection to avoid mysql timeout
         $this->managerRegistry->getManager()->getConnection()->close();
@@ -67,7 +70,7 @@ class ORMFixture implements ManagerRegistryFixture, AliceFixture, ORMPersistFixt
         $this->fixtures = $fixtures;
     }
 
-    public function setAlice(AliceLoader $alice)
+    public function setAlice(Loader $alice)
     {
         $this->alice = $alice;
     }

--- a/src/Rezzza/AliceExtension/Resources/services.xml
+++ b/src/Rezzza/AliceExtension/Resources/services.xml
@@ -59,23 +59,28 @@
             <tag name="event_dispatcher.subscriber" priority="0" />
         </service>
 
-        <service id="sf2.alice_extension.processor.registry" class="%sf2.alice_extension.processor.registry.class%" factory-service="behat.alice.container_proxy" factory-method="get">
+        <service id="sf2.alice_extension.processor.registry" class="%sf2.alice_extension.processor.registry.class%" >
+            <factory service="behat.alice.container_proxy" method="get" />
             <argument>alice_extension.processor.registry</argument>
         </service>
 
-        <service id="sf2.doctrine" class="%sf2.doctrine.class%" factory-service="behat.alice.container_proxy" factory-method="get">
+        <service id="sf2.doctrine" class="%sf2.doctrine.class%" >
+            <factory service="behat.alice.container_proxy" method="get" />
             <argument>doctrine</argument>
         </service>
 
-        <service id="sf2.elastica.resetter" class="FOS\ElasticaBundle\Index\Resetter" factory-service="behat.alice.container_proxy" factory-method="get">
+        <service id="sf2.elastica.resetter" class="FOS\ElasticaBundle\Index\Resetter" >
+            <factory service="behat.alice.container_proxy" method="get" />
             <argument>fos_elastica.resetter</argument>
         </service>
 
-        <service id="sf2.serializer" class="JMS\Serializer\Serializer" factory-service="behat.alice.container_proxy" factory-method="get">
+        <service id="sf2.serializer" class="JMS\Serializer\Serializer" >
+            <factory service="behat.alice.container_proxy" method="get" />
             <argument>fos_elastica.serializer</argument>
         </service>
 
-        <service id="sf2.elastica.index" class="FOS\ElasticaBundle\Elastica\Index" factory-service="behat.alice.container_proxy" factory-method="get">
+        <service id="sf2.elastica.index" class="FOS\ElasticaBundle\Elastica\Index" >
+            <factory service="behat.alice.container_proxy" method="get" />
             <argument>%behat.alice.elastica_index%</argument>
         </service>
 

--- a/src/Rezzza/AliceExtension/Symfony/ContainerProxy.php
+++ b/src/Rezzza/AliceExtension/Symfony/ContainerProxy.php
@@ -69,4 +69,14 @@ class ContainerProxy implements ContainerInterface
     {
         throw new \Exception('Unsupported method');
     }
+
+    /**
+     * @inheritdoc
+     */
+    public function initialized($id)
+    {
+        throw new \Exception('Unsupported method');
+    }
+
+
 }


### PR DESCRIPTION
#### Pain point

Currently the project is using an old version of [nelmio/alice](https://github.com/rezzza/alice-extension/blob/master/composer.json#L17) preventing it to be used on a SF3 app.

#### Proposal

- [x] Update  [nelmio/alice](https://github.com/nelmio/alice) to ~2.1
- [x] Use SF3 compatible factory service declaration
- [x] Force Fixture reference to be YAML compliant
- [x] Change composer.json with `"symfony/symfony": "~2.3|~3.0"`
