### PR TITLE
Speed up Purge process on postgresql

### DIFF
--- a/src/Rezzza/AliceExtension/Doctrine/ORMPurger.php
+++ b/src/Rezzza/AliceExtension/Doctrine/ORMPurger.php
@@ -112,11 +112,16 @@ class ORMPurger
             $entityManager->getConnection()->exec('SET foreign_key_checks = 0;');
         }
 
-        foreach ($tables as $tbl) {
-            if ($this->purgeMode === self::PURGE_MODE_DELETE) {
-                $entityManager->getConnection()->executeUpdate("DELETE IGNORE FROM " . $tbl);
-            } else {
-                $entityManager->getConnection()->executeUpdate($platform->getTruncateTableSQL($tbl, true));
+        //speed-up db purge
+        if ($platform instanceof PostgreSqlPlatform && $this->purgeMode === self::PURGE_MODE_TRUNCATE) {
+            $entityManager->getConnection()->executeUpdate(sprintf('TRUNCATE %s CASCADE;', implode(',',$tables)));
+        } else {
+            foreach ($tables as $tbl) {
+                if ($this->purgeMode === self::PURGE_MODE_DELETE) {
+                    $entityManager->getConnection()->executeUpdate("DELETE IGNORE FROM " . $tbl);
+                } else {
+                    $entityManager->getConnection()->executeUpdate($platform->getTruncateTableSQL($tbl, true));
+                }
             }
         }
 

--- a/src/Rezzza/AliceExtension/Doctrine/ORMPurger.php
+++ b/src/Rezzza/AliceExtension/Doctrine/ORMPurger.php
@@ -113,7 +113,7 @@ class ORMPurger
         }
 
         //speed-up db purge
-        if ($platform instanceof PostgreSqlPlatform && $this->purgeMode === self::PURGE_MODE_TRUNCATE) {
+        if ($platform instanceof PostgreSqlPlatform && $this->purgeMode === self::PURGE_MODE_TRUNCATE && count($tables)) {
             $entityManager->getConnection()->executeUpdate(sprintf('TRUNCATE %s CASCADE;', implode(',',$tables)));
         } else {
             foreach ($tables as $tbl) {


### PR DESCRIPTION
In my case with lot of tests (458 scenarios) and lifetime option set to 'scenario',
tests take 13 m without & 4m 30s with this optimization