### PR TITLE
Reset MySQL AUTO_INCREMENT when purging via DELETE

### DIFF
--- a/src/Rezzza/AliceExtension/Doctrine/ORMPurger.php
+++ b/src/Rezzza/AliceExtension/Doctrine/ORMPurger.php
@@ -115,6 +115,7 @@ class ORMPurger
         foreach ($tables as $tbl) {
             if ($this->purgeMode === self::PURGE_MODE_DELETE) {
                 $entityManager->getConnection()->executeUpdate("DELETE IGNORE FROM " . $tbl);
+                $entityManager->getConnection()->executeUpdate("ALTER TABLE $tbl AUTO_INCREMENT = 1");
             } else {
                 $entityManager->getConnection()->executeUpdate($platform->getTruncateTableSQL($tbl, true));
             }


### PR DESCRIPTION
#### Pain Point

We had to use the ORMPurger delete mode. It is not resetting the MySQL auto increment. Unlike the truncate mode.


Keep up the good work !